### PR TITLE
Fix Kafka admin event consumer deserialization

### DIFF
--- a/store/src/main/java/com/msa/store/config/KafkaConsumerConfig.java
+++ b/store/src/main/java/com/msa/store/config/KafkaConsumerConfig.java
@@ -23,6 +23,10 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.consumer.group-id}")
     private String groupId;
 
+    /**
+     * Kafka에서 수신한 관리자 이벤트를 역직렬화하기 위한 ConsumerFactory를 생성한다.
+     * Store 서비스에서 사용하는 DTO 타입을 기본 타입으로 지정해 역직렬화 실패를 방지한다.
+     */
     @Bean
     public ConsumerFactory<String, AdminEventDto> adminEventConsumerFactory() {
         Map<String, Object> props = new HashMap<>();
@@ -30,19 +34,21 @@ public class KafkaConsumerConfig {
         props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.msa.store.kafka.dto");
+        props.put(JsonDeserializer.TYPE_MAPPINGS, "adminEvent:com.msa.store.kafka.dto.AdminEventDto");
 
-        // 신뢰할 수 있는 패키지 설정 수정
-        props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.msa.member.kafka.dto,com.msa.store.kafka.dto");
-
-        // 타입 매핑 설정 수정
-        props.put(JsonDeserializer.TYPE_MAPPINGS, "adminEvent:com.msa.member.kafka.dto.AdminEventDto");
+        JsonDeserializer<AdminEventDto> valueDeserializer = new JsonDeserializer<>(AdminEventDto.class, false);
+        valueDeserializer.addTrustedPackages("com.msa.store.kafka.dto");
 
         return new DefaultKafkaConsumerFactory<>(
                 props,
                 new StringDeserializer(),
-                new JsonDeserializer<>(AdminEventDto.class, false));
+                valueDeserializer);
     }
 
+    /**
+     * 관리자 이벤트 전용 KafkaListenerContainerFactory를 생성하여 리스너가 올바른 ConsumerFactory를 사용하도록 한다.
+     */
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, AdminEventDto> adminEventKafkaListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, AdminEventDto> factory =

--- a/store/src/main/java/com/msa/store/kafka/consumer/AdminEventConsumer.java
+++ b/store/src/main/java/com/msa/store/kafka/consumer/AdminEventConsumer.java
@@ -15,6 +15,11 @@ public class AdminEventConsumer {
 
     private final StoreService storeService;
 
+    /**
+     * Kafka를 통해 전송된 관리자 이벤트를 수신하여 이벤트 유형에 맞게 처리한다.
+     *
+     * @param adminEvent 관리자의 생성/수정/삭제 이벤트 정보
+     */
     @KafkaListener(
             topics = "${kafka.topic.admin-events}",
             groupId = "${spring.kafka.consumer.group-id}",

--- a/store/src/main/java/com/msa/store/service/StoreService.java
+++ b/store/src/main/java/com/msa/store/service/StoreService.java
@@ -17,6 +17,12 @@ public class StoreService {
 
     private final StoreRepository storeRepository;
 
+    /**
+     * 관리자 생성 이벤트를 기반으로 신규 매장 정보를 저장한다.
+     * 이미 동일 관리자 정보가 존재하면 중복 생성을 방지하기 위해 저장하지 않는다.
+     *
+     * @param adminEvent 관리자 생성 이벤트
+     */
     @Transactional
     public void createAdmin(AdminEventDto adminEvent) {
         // 이미 존재하는 관리자인지 확인


### PR DESCRIPTION
## Summary
- align the store service's Kafka consumer configuration with the local AdminEvent DTO to allow message processing
- document the admin event consumer and service methods for clarity

## Testing
- ./gradlew :store:test *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68de30192a70832fbe33f2fb4a19830c